### PR TITLE
feat(http) allow to set http-client to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ local b, c, h = http_digest.request(url)
 
 See the tests for more.
 
+Other compatible http clients (like Copas or LuaSec) can be used as well. To use
+another http client replace the default one:
+
+```lua
+local http_digest = require "http-digest"
+http_digest.http = require "copas.http"
+```
+
 ## Note
 
 If you get this error when running the tests, update LuaSocket:
@@ -50,3 +58,4 @@ This only impacts the tests, the code itself works with older versions as well.
 ### x.x unreleased
 
 - fix: drop initial 401 response body instead of concatenating both responses
+- feat: made the http client configurable to be able to use Copas or LuaSec clients

--- a/http-digest.lua
+++ b/http-digest.lua
@@ -1,7 +1,10 @@
-local md5sum, md5_library
+local Digest = {}  -- module table
+
 local fmt = string.format
 
-do -- select MD5 library
+local md5sum do -- select MD5 library
+
+    local md5_library
 
     local ok, mod = pcall(require, "crypto")
     if ok then
@@ -27,11 +30,12 @@ do -- select MD5 library
         if md5sum then md5_library = "digest" end
     end
 
+    Digest.md5_library = md5_library
 end
 
 assert(md5sum, "cannot find supported md5 module")
 
-local s_http = require "socket.http"
+Digest.http = require "socket.http"
 local s_url = require "socket.url"
 local ltn12 = require "ltn12"
 
@@ -115,7 +119,7 @@ local _request = function(params)
     local client_sink = params.sink
     params.sink = ltn12.sink.table(responsebody)
 
-    local b, c, h = s_http.request(params)
+    local b, c, h = Digest.http.request(params)
     if (c == 401) and h["www-authenticate"] then
         local ht = parse_header(h["www-authenticate"])
         assert(ht.realm and ht.nonce)
@@ -161,7 +165,7 @@ local _request = function(params)
         end
         if params.source then params.source = ghost_source end
         params.sink = client_sink
-        b, c, h = s_http.request(params)
+        b, c, h = Digest.http.request(params)
         return b, c, h
     else
         -- only 1 request, copy contents of temporary sink to the client provided sink
@@ -170,7 +174,7 @@ local _request = function(params)
     end
 end
 
-local request = function(params)
+Digest.request = function(params)
     local t = type(params)
     if t == "table" then
         return _request(hcopy(params))
@@ -183,7 +187,4 @@ local request = function(params)
     end
 end
 
-return {
-    md5_library = md5_library,
-    request = request,
-}
+return Digest


### PR DESCRIPTION
This enables use with Copas or LuaSec http-clients (they are luasocket compatible)

fixes #9