### PR TITLE
feat(auth) also allow unauthenticated requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ This only impacts the tests, the code itself works with older versions as well.
 ### x.x unreleased
 
 - fix: drop initial 401 response body instead of concatenating both responses
+- feat: also allow unauthenticated requests. Only check for creds if they are
+  needed. If not provided return the original 401 response.

--- a/http-digest.lua
+++ b/http-digest.lua
@@ -86,11 +86,10 @@ end
 --- Main logic. `params` is always a table and can be modified.
 local _request = function(params)
     if not params.url then error("missing URL") end
+
+    -- parse url to collect and remove user/pwd
     local url = s_url.parse(params.url)
     local user, password = url.user, url.password
-    if not (user and password) then
-        error("missing credentials in URL")
-    end
     url.user, url.password, url.authority, url.userinfo = nil, nil, nil, nil
     params.url = s_url.build(url)
 
@@ -116,7 +115,7 @@ local _request = function(params)
     params.sink = ltn12.sink.table(responsebody)
 
     local b, c, h = s_http.request(params)
-    if (c == 401) and h["www-authenticate"] then
+    if (c == 401) and h["www-authenticate"] and (user and password) then
         local ht = parse_header(h["www-authenticate"])
         assert(ht.realm and ht.nonce)
         if ht.qop ~= "auth" then


### PR DESCRIPTION
This make it useable for both authenticated as well as unauthenticated requests, without the client code needing to switch/know.

NOTE: in case of no creds, it no longer return `nil+"error string"` but the original 401 response. This can be considered breaking, but imo this is the better option since it is more transparent.